### PR TITLE
TermCursor

### DIFF
--- a/colors/solarized8_dark.vim
+++ b/colors/solarized8_dark.vim
@@ -118,6 +118,10 @@ hi! CursorLine cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=0 guibg=#0736
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=0 guibg=#073642
 hi! Cursor cterm=NONE gui=NONE ctermfg=15 guifg=#fdf6e3 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=10 guibg=#586e75 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_dark_flat.vim
+++ b/colors/solarized8_dark_flat.vim
@@ -116,6 +116,10 @@ hi! CursorLine cterm=NONE,underline gui=NONE,underline ctermfg=NONE guifg=NONE c
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=0 guibg=#073642
 hi! Cursor cterm=NONE gui=NONE ctermfg=15 guifg=#fdf6e3 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=10 guibg=#586e75 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_dark_high.vim
+++ b/colors/solarized8_dark_high.vim
@@ -118,6 +118,10 @@ hi! CursorLine cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=0 guibg=#0736
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=0 guibg=#073642
 hi! Cursor cterm=NONE gui=NONE ctermfg=15 guifg=#fdf6e3 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=11 guibg=#657b83 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_dark_low.vim
+++ b/colors/solarized8_dark_low.vim
@@ -118,6 +118,10 @@ hi! CursorLine cterm=NONE,underline gui=NONE,underline ctermfg=NONE guifg=NONE c
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=0 guibg=#073642
 hi! Cursor cterm=NONE gui=NONE ctermfg=15 guifg=#fdf6e3 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=10 guibg=#586e75 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_light.vim
+++ b/colors/solarized8_light.vim
@@ -118,6 +118,10 @@ hi! CursorLine cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=7 guibg=#eee8
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=7 guibg=#eee8d5
 hi! Cursor cterm=NONE gui=NONE ctermfg=8 guifg=#002b36 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=14 guibg=#93a1a1 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_light_flat.vim
+++ b/colors/solarized8_light_flat.vim
@@ -116,6 +116,10 @@ hi! CursorLine cterm=NONE,underline gui=NONE,underline ctermfg=NONE guifg=NONE c
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=7 guibg=#eee8d5
 hi! Cursor cterm=NONE gui=NONE ctermfg=8 guifg=#002b36 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=14 guibg=#93a1a1 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_light_high.vim
+++ b/colors/solarized8_light_high.vim
@@ -118,6 +118,10 @@ hi! CursorLine cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=7 guibg=#eee8
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=7 guibg=#eee8d5
 hi! Cursor cterm=NONE gui=NONE ctermfg=8 guifg=#002b36 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=11 guibg=#657b83
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/colors/solarized8_light_low.vim
+++ b/colors/solarized8_light_low.vim
@@ -118,6 +118,10 @@ hi! CursorLine cterm=NONE,underline gui=NONE,underline ctermfg=NONE guifg=NONE c
 hi! ColorColumn cterm=NONE gui=NONE ctermfg=NONE guifg=NONE ctermbg=7 guibg=#eee8d5
 hi! Cursor cterm=NONE gui=NONE ctermfg=8 guifg=#002b36 ctermbg=4 guibg=#268bd2
 hi! link lCursor Cursor
+if has('nvim')
+  hi! link TermCursor Cursor
+  hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=14 guibg=#93a1a1 cterm=NONE gui=NONE
+endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496
 hi! link vimVar Identifier
 hi! link vimFunc Function

--- a/src/solarized8.vim
+++ b/src/solarized8.vim
@@ -466,6 +466,12 @@ for s:solarized_background in ["dark", "light"]
     call s:put("hi! ColorColumn"    .s:fmt_none   .s:fg_none   .s:bg_base02)
     call s:put("hi! Cursor"         .s:fmt_none   .s:fg_base3  .s:bg_blue)
     call s:put("hi! link lCursor Cursor")
+
+    call s:put("if has('nvim')")
+    call s:put("  hi! link TermCursor Cursor")
+    call s:put("  hi! TermCursorNC"   .s:fg_base03  .s:bg_base01  .s:fmt_none)
+    call s:put("endif")
+
     " Changed by Lifepillar: better (in my opinion) highlighting for MatchParen:
     if s:solarized_background == 'dark'
       call s:put("hi! MatchParen"     .s:fmt_bold   .s:fg_base3  .s:bg_base02)


### PR DESCRIPTION
Fixes #7.

As an initial proposal, I've used orange for the focussed terminal cursor, and shades of grey for the unfocussed terminal cursor. e.g.:

<img width="1028" alt="term-cursor" src="https://cloud.githubusercontent.com/assets/7069/22952365/a339d978-f304-11e6-98e4-0a547f05688f.png">

I'm happy to accept feedback.