### PR TITLE
Terminal colors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,10 @@ For terminals not supporting true colors, the requirement is the same as for the
 other color schemes: your 16 terminal ASCII colors must be set to the Solarized
 palette. The ugly degraded 256-color variant has been removed.
 
+In NeoVim, Solarized 8 defines a color palette for the [terminal
+emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html), as well as
+specifying colors for the `TermCursor` and `TermCursorNC` highlight groups.
+
 
 ## Installation
 
@@ -86,7 +90,7 @@ favourite true-color enabled terminal!**
 
 Try putting this in your `.vimrc`:
 
-```
+```viml
 let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
 let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
 ```
@@ -99,7 +103,7 @@ See `:h xterm-true-color` for the details.
 If you want to quickly toggle between dark and light background, you may define
 a mapping like the following:
 
-```
+```viml
 nnoremap  <leader>B :<c-u>exe "colors" (g:colors_name =~# "dark"
     \ ? substitute(g:colors_name, 'dark', 'light', '')
     \ : substitute(g:colors_name, 'light', 'dark', '')
@@ -108,7 +112,7 @@ nnoremap  <leader>B :<c-u>exe "colors" (g:colors_name =~# "dark"
 
 To tune the contrast level you may use the following snippet:
 
-```
+```viml
 fun! Solarized8Contrast(delta)
   let l:schemes = map(["_low", "_flat", "", "_high"], '"solarized8_".(&background).v:val')
   exe "colors" l:schemes[((a:delta+index(l:schemes, g:colors_name)) % 4 + 4) % 4]

--- a/colors/solarized8_dark.vim
+++ b/colors/solarized8_dark.vim
@@ -121,6 +121,22 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=10 guibg=#586e75 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier

--- a/colors/solarized8_dark_flat.vim
+++ b/colors/solarized8_dark_flat.vim
@@ -119,6 +119,22 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=10 guibg=#586e75 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier

--- a/colors/solarized8_dark_high.vim
+++ b/colors/solarized8_dark_high.vim
@@ -131,6 +131,7 @@ if has('nvim')
   let g:terminal_color_7 = '#eee8d5'
   let g:terminal_color_8 = '#002b36'
   let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
   let g:terminal_color_11 = '#657b83'
   let g:terminal_color_12 = '#839496'
   let g:terminal_color_13 = '#6c71c4'

--- a/colors/solarized8_dark_high.vim
+++ b/colors/solarized8_dark_high.vim
@@ -121,6 +121,21 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=11 guibg=#657b83 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier

--- a/colors/solarized8_dark_low.vim
+++ b/colors/solarized8_dark_low.vim
@@ -121,6 +121,22 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=8 guifg=#002b36 ctermbg=10 guibg=#586e75 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=0 guibg=#073642
 hi! link vimVar Identifier

--- a/colors/solarized8_light.vim
+++ b/colors/solarized8_light.vim
@@ -121,6 +121,22 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=14 guibg=#93a1a1 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496
 hi! link vimVar Identifier

--- a/colors/solarized8_light_flat.vim
+++ b/colors/solarized8_light_flat.vim
@@ -119,6 +119,22 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=14 guibg=#93a1a1 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496
 hi! link vimVar Identifier

--- a/colors/solarized8_light_high.vim
+++ b/colors/solarized8_light_high.vim
@@ -121,6 +121,21 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=11 guibg=#657b83
 hi! link vimVar Identifier

--- a/colors/solarized8_light_high.vim
+++ b/colors/solarized8_light_high.vim
@@ -135,6 +135,7 @@ if has('nvim')
   let g:terminal_color_11 = '#657b83'
   let g:terminal_color_12 = '#839496'
   let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
   let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=11 guibg=#657b83

--- a/colors/solarized8_light_low.vim
+++ b/colors/solarized8_light_low.vim
@@ -121,6 +121,22 @@ hi! link lCursor Cursor
 if has('nvim')
   hi! link TermCursor Cursor
   hi! TermCursorNC ctermfg=15 guifg=#fdf6e3 ctermbg=14 guibg=#93a1a1 cterm=NONE gui=NONE
+  let g:terminal_color_0 = '#073642'
+  let g:terminal_color_1 = '#dc322f'
+  let g:terminal_color_2 = '#719e07'
+  let g:terminal_color_3 = '#b58900'
+  let g:terminal_color_4 = '#268bd2'
+  let g:terminal_color_5 = '#d33682'
+  let g:terminal_color_6 = '#2aa198'
+  let g:terminal_color_7 = '#eee8d5'
+  let g:terminal_color_8 = '#002b36'
+  let g:terminal_color_9 = '#cb4b16'
+  let g:terminal_color_10 = '#586e75'
+  let g:terminal_color_11 = '#657b83'
+  let g:terminal_color_12 = '#839496'
+  let g:terminal_color_13 = '#6c71c4'
+  let g:terminal_color_14 = '#93a1a1'
+  let g:terminal_color_15 = '#fdf6e3'
 endif
 hi! MatchParen cterm=NONE,bold gui=NONE,bold ctermfg=15 guifg=#fdf6e3 ctermbg=12 guibg=#839496
 hi! link vimVar Identifier

--- a/src/solarized8.vim
+++ b/src/solarized8.vim
@@ -46,6 +46,7 @@ for s:solarized_background in ["dark", "light"]
     let s:b           = ",bold"
     let s:i           = ",italic"
     let s:u           = ""
+    let s:placeholder = ["",""]
 
     if s:solarized_background == "light"
       let s:temp03      = s:base03
@@ -64,6 +65,7 @@ for s:solarized_background in ["dark", "light"]
     endif
 
     if s:solarized_contrast == "high"
+      let s:placeholder = s:base01
       let s:base01      = s:base00
       let s:base00      = s:base0
       let s:base0       = s:base1
@@ -486,7 +488,8 @@ for s:solarized_background in ["dark", "light"]
           \ s:violet,
           \ s:blue,
           \ s:cyan,
-          \ s:green
+          \ s:green,
+          \ s:placeholder
           \ ]
     let s:colorTableIndices = map(copy(s:colorTable), 'v:val[0]')
     let s:colorTableCodes   = map(copy(s:colorTable), 'v:val[1]')

--- a/src/solarized8.vim
+++ b/src/solarized8.vim
@@ -470,6 +470,33 @@ for s:solarized_background in ["dark", "light"]
     call s:put("if has('nvim')")
     call s:put("  hi! link TermCursor Cursor")
     call s:put("  hi! TermCursorNC"   .s:fg_base03  .s:bg_base01  .s:fmt_none)
+    let s:colorTable = [
+          \ s:base03,
+          \ s:base02,
+          \ s:base01,
+          \ s:base00,
+          \ s:base0,
+          \ s:base1,
+          \ s:base2,
+          \ s:base3,
+          \ s:yellow,
+          \ s:orange,
+          \ s:red,
+          \ s:magenta,
+          \ s:violet,
+          \ s:blue,
+          \ s:cyan,
+          \ s:green
+          \ ]
+    let s:colorTableIndices = map(copy(s:colorTable), 'v:val[0]')
+    let s:colorTableCodes   = map(copy(s:colorTable), 'v:val[1]')
+
+    for s:num in [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
+      let s:matchIndex = index(s:colorTableIndices, string(s:num))
+      if s:matchIndex >= 0
+        call s:put("  let g:terminal_color_" . s:num . " = '" . s:colorTableCodes[s:matchIndex] . "'")
+      endif
+    endfor
     call s:put("endif")
 
     " Changed by Lifepillar: better (in my opinion) highlighting for MatchParen:


### PR DESCRIPTION
Fixes #9.

- [x] define a terminal color palette using colors from Solarized 8
- [x] add documentation in Readme
- [x] make the `terminal_colors.vim` file be generated from `src/solarized8.vim` (to ensure colors stay in sync)
- [x] test color palette with both light and dark themes