### PR TITLE
add tmux check condition

### DIFF
--- a/scripts/solarized8.sh
+++ b/scripts/solarized8.sh
@@ -16,7 +16,7 @@ if [ "${TERM%%-*}" = 'linux' ]; then
   return 2>/dev/null || exit 0
 fi
 
-if [ -n "$TMUX" ]; then
+if [[ "$TERM" =~ "^screen.*" && -n "$TMUX" ]]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
   printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"


### PR DESCRIPTION
for #56 

if I start vncserver in tmux, then after I open terminal in vnc, `$TMUX` has been set. 
so I add tmux check condition.

Tmux default set `$TMUX` and set `$TERM` to `screen`.
This isn't a 100% reliable indicator also. (ex.  if you set `TERM="xterm-256color"` in `.zshrc`, then `TERM` in tmux is `xterm-256color`)