### PR TITLE
Allow 'solarized8.txt' to be listed in the LOCAL ADDITIONS section of help.txt

### DIFF
--- a/doc/solarized8.txt
+++ b/doc/solarized8.txt
@@ -1,4 +1,3 @@
-*solarized8.txt*	For Vim version 7.4	Last change: 2019 March 26
 ==============================================================================
 Solarized 8 license		*solarized8-license*
 

--- a/doc/solarized8.txt
+++ b/doc/solarized8.txt
@@ -1,3 +1,4 @@
+*solarized8.txt*	For Vim version 7.4	Last change: 2019 March 26
 ==============================================================================
 Solarized 8 license		*solarized8-license*
 

--- a/templates/_help.colortemplate
+++ b/templates/_help.colortemplate
@@ -1,6 +1,7 @@
 # vim: ft=colortemplate fdm=marker tw=78 ts=8 norl
 
 documentation
+*@shortname.txt*	For Vim version 7.4	Last change: 2019 March 26
 ==============================================================================
 @fullname license		*@shortname-license*
 


### PR DESCRIPTION
The first field is a link to the help file name. The second field describes the applicable Vim version. The last field specifies the last modification date of the file. Each field is separated by a tab. (See :h help-writing)