### PR TITLE
Add additional suggestion for tmux colors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -178,6 +178,17 @@ let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
 
 See `:h xterm-true-color` for the details.
 
+It may also be necessary to add the following to your `tmux.conf`:
+
+```
+# Add truecolor support
+set-option -ga terminal-overrides ",xterm-256color:Tc"
+# Default terminal is 256 colors
+set -g default-terminal "screen-256color"
+```
+
+See the discussion [here](https://github.com/lifepillar/vim-solarized8/issues/4#issuecomment-985416964) for context.
+
 
 ## Hacking
 


### PR DESCRIPTION
I was getting the odd orange/black colors in tmux until I followed the suggestion [here](https://github.com/lifepillar/vim-solarized8/issues/4#issuecomment-985416964). It might be nice to make it more visible for other people. I said "may" because I don't fully understand why these options are needed in tmux and maybe the theme is working for some people without them?