### PR TITLE
add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Vim files should be checked out in unix format
+# Vim should always be able to source those
+# but e.g. Unix Vim may not able to source *.vim with crlf ending
+*.vim text eol=lf


### PR DESCRIPTION
When checking out this repository on WSL (or even on Unix), the Vim files have `CRLF` style line-endings, which make sourcing a pain, because Vim complains loudly about that `^M` character:
![image](https://user-images.githubusercontent.com/244927/234856593-cba1dfea-837a-493e-a056-133023d5b694.png)

So let's use a gitattributes file and mark `*.vim` files to be checked out with LF line-endings.
