### PR TITLE
Update highlight groups for Neovim capture.

### DIFF
--- a/colors/solarized8.vim
+++ b/colors/solarized8.vim
@@ -60,6 +60,14 @@ hi! link NormalNC Normal
 hi! link TermCursor Cursor
 hi! link WinBarNC WinBar
 hi! link WinSeparator VertSplit
+hi! link @variable Normal
+hi! link @variable.builtin Identifier
+hi! link @keyword Keyword
+hi! link @function Function
+hi! link @type Type
+hi! link @constant Constant
+hi! link @string String
+hi! link @comment Comment
 
 if &background ==# 'dark'
   let g:terminal_color_0 = '#073642'

--- a/colors/solarized8_flat.vim
+++ b/colors/solarized8_flat.vim
@@ -61,6 +61,15 @@ hi! link TermCursor Cursor
 hi! link WinBarNC WinBar
 hi! link WinSeparator VertSplit
 
+hi! link @variable Normal
+hi! link @variable.builtin Identifier
+hi! link @keyword Keyword
+hi! link @function Function
+hi! link @type Type
+hi! link @constant Constant
+hi! link @string String
+hi! link @comment Comment
+
 if &background ==# 'dark'
   let g:terminal_color_0 = '#073642'
   let g:terminal_color_1 = '#dc322f'

--- a/colors/solarized8_high.vim
+++ b/colors/solarized8_high.vim
@@ -60,6 +60,14 @@ hi! link NormalNC Normal
 hi! link TermCursor Cursor
 hi! link WinBarNC WinBar
 hi! link WinSeparator VertSplit
+hi! link @variable Normal
+hi! link @variable.builtin Identifier
+hi! link @keyword Keyword
+hi! link @function Function
+hi! link @type Type
+hi! link @constant Constant
+hi! link @string String
+hi! link @comment Comment
 
 if &background ==# 'dark'
   let g:terminal_color_0 = '#073642'

--- a/colors/solarized8_low.vim
+++ b/colors/solarized8_low.vim
@@ -60,6 +60,14 @@ hi! link NormalNC Normal
 hi! link TermCursor Cursor
 hi! link WinBarNC WinBar
 hi! link WinSeparator VertSplit
+hi! link @variable Normal
+hi! link @variable.builtin Identifier
+hi! link @keyword Keyword
+hi! link @function Function
+hi! link @type Type
+hi! link @constant Constant
+hi! link @string String
+hi! link @comment Comment
 
 if &background ==# 'dark'
   let g:terminal_color_0 = '#073642'


### PR DESCRIPTION
Using the `neovim`  branch of `vim-solarized8` in neovim with treesitter I was seeing non-pallete colors for variable names e.g. in lua variables show as white (and similarly in other languages):

<img width="504" height="193" alt="image" src="https://github.com/user-attachments/assets/0519dea9-4f62-48f6-9b09-f4a43ac7a575" />

This PR fixes this by defining the capture-highlights for all the solarized8 variants.

e.g.

<img width="516" height="163" alt="image" src="https://github.com/user-attachments/assets/7ee20504-ec6f-4f99-930f-4b4f6583704e" />
 